### PR TITLE
Update partitioning fields for okta & aad tables

### DIFF
--- a/src/tests/smoke01/expected/02_dlt_edges.sql
+++ b/src/tests/smoke01/expected/02_dlt_edges.sql
@@ -6,10 +6,11 @@
 
 -- COMMAND ----------
 CREATE STREAMING LIVE TABLE okta_edges_silver
-PARTITIONED BY (event_ts)
+PARTITIONED BY (event_date, sub_id)
 TBLPROPERTIES("quality"="silver")
 AS
 SELECT event_ts,
+  event_date,
   rid as src_rid,
   'user-okta' as sub_type,
   raw:actor.id as sub_id,
@@ -34,7 +35,7 @@ WHERE raw:eventType IN ('user.authentication.auth_via_mfa', 'user.authentication
 
 -- COMMAND ----------
 CREATE STREAMING LIVE TABLE okta_edges_gold_DAY
-PARTITIONED BY (time_bkt)
+PARTITIONED BY (time_bkt, sub_id)
 TBLPROPERTIES("quality"="gold")
 AS
 SELECT date_trunc('DAY', event_ts) as time_bkt, sub_type, sub_id, sub_name, pred, pred_status, obj_type, obj_id, obj_name,
@@ -47,10 +48,11 @@ group by time_bkt, sub_type, sub_id, sub_name, pred, pred_status, obj_type, obj_
 ;
 -- COMMAND ----------
 CREATE STREAMING LIVE TABLE aad_edges_silver
-PARTITIONED BY (event_ts)
+PARTITIONED BY (event_date, sub_id)
 TBLPROPERTIES("quality"="silver")
 AS
 SELECT event_ts,
+  event_date,
   rid AS src_rid,
   'user-aad' AS sub_type,
   raw:userId AS sub_id,
@@ -65,7 +67,7 @@ FROM STREAM(solacc_cga.aad_bronze);
 
 -- COMMAND ----------
 CREATE STREAMING LIVE TABLE aad_edges_gold_DAY
-PARTITIONED BY (time_bkt)
+PARTITIONED BY (time_bkt, sub_id)
 TBLPROPERTIES("quality"="gold")
 AS
 SELECT date_trunc('DAY', event_ts) as time_bkt,

--- a/templates/aad_gold.sql
+++ b/templates/aad_gold.sql
@@ -1,5 +1,5 @@
 CREATE STREAMING LIVE TABLE aad_edges_gold_{{time_granularity}}
-PARTITIONED BY (time_bkt)
+PARTITIONED BY (time_bkt, sub_id)
 TBLPROPERTIES("quality"="gold")
 AS
 SELECT date_trunc('{{time_granularity}}', event_ts) as time_bkt,

--- a/templates/aad_silver.sql
+++ b/templates/aad_silver.sql
@@ -1,8 +1,9 @@
 CREATE STREAMING LIVE TABLE aad_edges_silver
-PARTITIONED BY (event_ts)
+PARTITIONED BY (event_date, sub_id)
 TBLPROPERTIES("quality"="silver")
 AS
 SELECT event_ts,
+  event_date,
   rid AS src_rid,
   'user-aad' AS sub_type,
   raw:userId AS sub_id,

--- a/templates/okta_gold.sql
+++ b/templates/okta_gold.sql
@@ -1,5 +1,5 @@
 CREATE STREAMING LIVE TABLE okta_edges_gold_{{time_granularity}}
-PARTITIONED BY (time_bkt)
+PARTITIONED BY (time_bkt, sub_id)
 TBLPROPERTIES("quality"="gold")
 AS
 SELECT date_trunc('{{time_granularity}}', event_ts) as time_bkt, sub_type, sub_id, sub_name, pred, pred_status, obj_type, obj_id, obj_name,

--- a/templates/okta_silver.sql
+++ b/templates/okta_silver.sql
@@ -1,8 +1,9 @@
 CREATE STREAMING LIVE TABLE okta_edges_silver
-PARTITIONED BY (event_ts)
+PARTITIONED BY (event_date, sub_id)
 TBLPROPERTIES("quality"="silver")
 AS
 SELECT event_ts,
+  event_date,
   rid as src_rid,
   'user-okta' as sub_type,
   raw:actor.id as sub_id,


### PR DESCRIPTION
Change partitioning at silver level to event_date and add sub_id as second partitioning field to gold tables - this is to improve performance in the test drive use case.