### PR TITLE
Finetune partitioning for aad, okta

### DIFF
--- a/src/tests/smoke01/expected/02_dlt_edges.sql
+++ b/src/tests/smoke01/expected/02_dlt_edges.sql
@@ -6,11 +6,12 @@
 
 -- COMMAND ----------
 CREATE STREAMING LIVE TABLE okta_edges_silver
-PARTITIONED BY (event_date, sub_id)
+PARTITIONED BY (event_date, pt)
 TBLPROPERTIES("quality"="silver")
 AS
 SELECT event_ts,
   event_date,
+  left(sub_id, 1) as pt,
   rid as src_rid,
   'user-okta' as sub_type,
   raw:actor.id as sub_id,
@@ -35,10 +36,12 @@ WHERE raw:eventType IN ('user.authentication.auth_via_mfa', 'user.authentication
 
 -- COMMAND ----------
 CREATE STREAMING LIVE TABLE okta_edges_gold_DAY
-PARTITIONED BY (time_bkt, sub_id)
+PARTITIONED BY (time_bkt, pt)
 TBLPROPERTIES("quality"="gold")
 AS
-SELECT date_trunc('DAY', event_ts) as time_bkt, sub_type, sub_id, sub_name, pred, pred_status, obj_type, obj_id, obj_name,
+SELECT date_trunc('DAY', event_ts) as time_bkt,
+  left(sub_id, 1) as pt,
+  sub_type, sub_id, sub_name, pred, pred_status, obj_type, obj_id, obj_name,
   min(event_ts) as first_seen,
   max(event_ts) as last_seen,
   count(*) as cnt
@@ -48,11 +51,12 @@ group by time_bkt, sub_type, sub_id, sub_name, pred, pred_status, obj_type, obj_
 ;
 -- COMMAND ----------
 CREATE STREAMING LIVE TABLE aad_edges_silver
-PARTITIONED BY (event_date, sub_id)
+PARTITIONED BY (event_date, pt)
 TBLPROPERTIES("quality"="silver")
 AS
 SELECT event_ts,
   event_date,
+  left(raw:userId, 1) as pt,
   rid AS src_rid,
   'user-aad' AS sub_type,
   raw:userId AS sub_id,
@@ -67,10 +71,11 @@ FROM STREAM(solacc_cga.aad_bronze);
 
 -- COMMAND ----------
 CREATE STREAMING LIVE TABLE aad_edges_gold_DAY
-PARTITIONED BY (time_bkt, sub_id)
+PARTITIONED BY (time_bkt, pt)
 TBLPROPERTIES("quality"="gold")
 AS
 SELECT date_trunc('DAY', event_ts) as time_bkt,
+  left(sub_id, 1) as pt,
   sub_type, sub_id, sub_name,
   pred, pred_status,
   obj_type, obj_id, obj_name,

--- a/src/tests/smoke01/expected/02_dlt_edges.sql
+++ b/src/tests/smoke01/expected/02_dlt_edges.sql
@@ -11,7 +11,7 @@ TBLPROPERTIES("quality"="silver")
 AS
 SELECT event_ts,
   event_date,
-  left(sub_id, 1) as pt,
+  left(raw:actor.id, 1) as pt,
   rid as src_rid,
   'user-okta' as sub_type,
   raw:actor.id as sub_id,

--- a/templates/aad_gold.sql
+++ b/templates/aad_gold.sql
@@ -1,8 +1,9 @@
 CREATE STREAMING LIVE TABLE aad_edges_gold_{{time_granularity}}
-PARTITIONED BY (time_bkt, sub_id)
+PARTITIONED BY (time_bkt, pt)
 TBLPROPERTIES("quality"="gold")
 AS
 SELECT date_trunc('{{time_granularity}}', event_ts) as time_bkt,
+  left(sub_id, 1) as pt,
   sub_type, sub_id, sub_name,
   pred, pred_status,
   obj_type, obj_id, obj_name,

--- a/templates/aad_silver.sql
+++ b/templates/aad_silver.sql
@@ -1,9 +1,10 @@
 CREATE STREAMING LIVE TABLE aad_edges_silver
-PARTITIONED BY (event_date, sub_id)
+PARTITIONED BY (event_date, pt)
 TBLPROPERTIES("quality"="silver")
 AS
 SELECT event_ts,
   event_date,
+  left(raw:userId, 1) as pt,
   rid AS src_rid,
   'user-aad' AS sub_type,
   raw:userId AS sub_id,

--- a/templates/okta_gold.sql
+++ b/templates/okta_gold.sql
@@ -1,8 +1,10 @@
 CREATE STREAMING LIVE TABLE okta_edges_gold_{{time_granularity}}
-PARTITIONED BY (time_bkt, sub_id)
+PARTITIONED BY (time_bkt, pt)
 TBLPROPERTIES("quality"="gold")
 AS
-SELECT date_trunc('{{time_granularity}}', event_ts) as time_bkt, sub_type, sub_id, sub_name, pred, pred_status, obj_type, obj_id, obj_name,
+SELECT date_trunc('{{time_granularity}}', event_ts) as time_bkt,
+  left(sub_id, 1) as pt,
+  sub_type, sub_id, sub_name, pred, pred_status, obj_type, obj_id, obj_name,
   min(event_ts) as first_seen,
   max(event_ts) as last_seen,
   count(*) as cnt

--- a/templates/okta_silver.sql
+++ b/templates/okta_silver.sql
@@ -1,9 +1,10 @@
 CREATE STREAMING LIVE TABLE okta_edges_silver
-PARTITIONED BY (event_date, sub_id)
+PARTITIONED BY (event_date, pt)
 TBLPROPERTIES("quality"="silver")
 AS
 SELECT event_ts,
   event_date,
+  left(sub_id, 1) as pt,
   rid as src_rid,
   'user-okta' as sub_type,
   raw:actor.id as sub_id,

--- a/templates/okta_silver.sql
+++ b/templates/okta_silver.sql
@@ -4,7 +4,7 @@ TBLPROPERTIES("quality"="silver")
 AS
 SELECT event_ts,
   event_date,
-  left(sub_id, 1) as pt,
+  left(raw:actor.id, 1) as pt,
   rid as src_rid,
   'user-okta' as sub_type,
   raw:actor.id as sub_id,


### PR DESCRIPTION
Sub_id results in too many small files. Change to the first char of sub_id to reduce number of files.